### PR TITLE
refactor: inject passphrases directly to patch.py instead of running script modifications

### DIFF
--- a/src/util_functions.sh
+++ b/src/util_functions.sh
@@ -188,6 +188,10 @@ function patch_ota() {
     args+=("--sign-key-ota" "${KEYS[OTA]}")
     args+=("--sign-cert-ota" "${KEYS[CERT_OTA]}")
 
+    # Passphrases for AVB and OTA keys
+    args+=("--pass-avb-env-var" "PASSPHRASE_AVB")
+    args+=("--pass-ota-env-var" "PASSPHRASE_OTA")
+
     # Modules
     args+=("--module-custota" "${WORKDIR}/modules/custota.zip")
     args+=("--module-msd" "${WORKDIR}/modules/msd.zip")
@@ -218,13 +222,7 @@ function my_avbroot_setup() {
   local location_path="${DOMAIN}/${USER}/${REPOSITORY}/releases/download/${VERSION[GRAPHENEOS]}/${OUTPUTS[PATCHED_OTA]}"
 
   # Add support to pass env-vars to the setup script for passphrase in the CI/CD pipeline
-  echo "Running script modifications..."
-  sed -i -e "/'avbroot', 'ota', 'patch',/a \\
-  \t\t'--pass-avb-env-var', 'PASSPHRASE_AVB',\\
-  \t\t'--pass-ota-env-var', 'PASSPHRASE_OTA'," "${setup_script}"
-
-  sed -i -e "/custota-tool', 'gen-csig',/a \\
-  \t\t'--passphrase-env-var', 'PASSPHRASE_OTA'," "${setup_script}"
+  echo -e "Running script modifications..."
 
   # Update location path to use GitHub releases
   sed -i -e "s|generate_update_info(update_info, args.output.name)|generate_update_info(update_info, '${location_path}')|" "${setup_script}"


### PR DESCRIPTION
previously, we used `sed` commands to modify the `patch.py` to inject passphrases something as below:

```
sed -i -e "/'avbroot', 'ota', 'patch',/a \\
	\t\t'--pass-avb-env-var', 'PASSPHRASE_AVB',\\
	\t\t'--pass-ota-env-var', 'PASSPHRASE_OTA'," "${setup_script}"
sed -i -e "/custota-tool', 'gen-csig',/a \\
	\t\t'--passphrase-env-var', 'PASSPHRASE_OTA'," "${setup_script}"
```

With https://github.com/chenxiaolong/my-avbroot-setup/commit/ac5ddd2059ef443f1431b510ca026f56e8d442b6 https://github.com/chenxiaolong/my-avbroot-setup/commit/5ba67266517cd3990e912ce08bb2591102ed249d, we do need to modify the the file to inject using `sed` at all.

