### PR TITLE
refactor: move env check from ci to util_functions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,21 +59,8 @@ jobs:
       - name: Read from `env.toml` if exist
         if: ${{ github.event_name == 'schedule' }}
         run: |
-          toml_file="env.toml"
-          if [ -f "$toml_file" ]; then
-
-            # Read the toml file and extract the required variables
-            DEVICE_NAME=$(grep '^device_name =' "$toml_file" | sed -E 's/^device_name *= *"([^"]*)"/\1/')
-            GRAPHENEOS_UPDATE_CHANNEL=$(grep '^update_channel =' "$toml_file" | sed -E 's/^update_channel *= *"([^"]*)"/\1/')
-
-            # Export the variables
-            echo "DEVICE_NAME=${DEVICE_NAME}" >> $GITHUB_ENV
-            echo "GRAPHENEOS_UPDATE_CHANNEL=${GRAPHENEOS_UPDATE_CHANNEL}" >> $GITHUB_ENV
-
-            # Print the variables for user reference
-            echo "DEVICE_NAME: $DEVICE_NAME"
-            echo "GRAPHENEOS_UPDATE_CHANNEL: $GRAPHENEOS_UPDATE_CHANNEL"
-          fi
+          # Check if the file exists
+          source src/util_functions.sh && check_toml_env
 
       - name: Check if a build exists already and verify assets
         shell: bash

--- a/src/USAGE.md
+++ b/src/USAGE.md
@@ -1,0 +1,38 @@
+# Getting started
+
+PixeneOS is a bash script for patching GrapheneOS OTA images with custom modules.
+This tool offers many features which are highly dependent on upstream projects.
+
+Linux based OS is recommended.
+
+To get started, clone the repository and run the following commands:
+
+- Modify `env.toml` file to set the environment variables
+- To run the program E2E (end to end), execute the following command:
+
+  ```bash
+  source src/main.sh --local
+  ```
+
+  > [!IMPORTANT]
+  > Make sure that `env.toml` file exist in root of the project.
+
+  `local` command calls `check_toml_env` function to check if `env.toml` file exists in root of the project and if it exist, it will read the toml file and set the environment variables accordingly.
+
+## Commands
+
+- Execute the following command to see the list of available commands and other helpful information:
+
+  ```bash
+  source src/util_functions.sh && help
+  ```
+
+  `help` command will display the help message.
+
+## Execution
+
+To call individual functions / commands, execute the following command:
+
+```bash
+source  src/<file>.sh && <function_name>
+```

--- a/src/main.sh
+++ b/src/main.sh
@@ -10,6 +10,11 @@ source src/fetcher.sh
 source src/util_functions.sh
 
 function main() {
+  if [[ "${INTERACTIVE_MODE}" == "true" ]]; then
+    echo -e "Running in interactive mode...\n"
+    check_toml_env
+  fi
+
   # Fetch the latest version of GrapheneOS and Magisk
   get_latest_version
   # Check for requirements and download them accordingly


### PR DESCRIPTION
this pr moves env file check from ci to util_functions just so that it can be used else where in the form of a function.

in addition to that, usage.md has been added for reference (still incomplete, but gets the job done).

adds `supported_tools` and `help` function