### PR TITLE
ci: fix renovate looking for file at wrong path

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,49 +5,49 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["declarations.sh"],
+      "fileMatch": ["src/declarations.sh"],
       "matchStrings": [ "VERSION[AFSR]=\\$\\{VERSION[AFSR]:-(?<currentValue>.*?)\\}" ],
       "depNameTemplate": "chenxiaolong/avbroot",
       "datasourceTemplate": "github-releases"
     },
    {
       "customType": "regex",
-      "fileMatch": ["declarations.sh"],
+      "fileMatch": ["src/declarations.sh"],
       "matchStrings": [ "VERSION[AVBROOT]=\\$\\{VERSION[AVBROOT]:-(?<currentValue>.*?)\\}" ],
       "depNameTemplate": "chenxiaolong/avbroot",
       "datasourceTemplate": "github-releases"
-    }, 
+    },
    {
       "customType": "regex",
-      "fileMatch": ["declarations.sh"],
+      "fileMatch": ["src/declarations.sh"],
       "matchStrings": [ "VERSION[ALTERINSTALLER]=\\$\\{VERSION[ALTERINSTALLER]:-(?<currentValue>.*?)\\}" ],
       "depNameTemplate": "chenxiaolong/avbroot",
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
-      "fileMatch": ["declarations.sh"],
+      "fileMatch": ["src/declarations.sh"],
       "matchStrings": [ "VERSION[CUSTOTA]=\\$\\{VERSION[CUSTOTA]:-(?<currentValue>.*?)\\}" ],
       "depNameTemplate": "chenxiaolong/avbroot",
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
-      "fileMatch": ["declarations.sh"],
+      "fileMatch": ["src/declarations.sh"],
       "matchStrings": [ "VERSION[MSD]=\\$\\{VERSION[MSD]:-(?<currentValue>.*?)\\}" ],
       "depNameTemplate": "chenxiaolong/avbroot",
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
-      "fileMatch": ["declarations.sh"],
+      "fileMatch": ["src/declarations.sh"],
       "matchStrings": [ "VERSION[BCR]=\\$\\{VERSION[BCR]:-(?<currentValue>.*?)\\}" ],
       "depNameTemplate": "chenxiaolong/avbroot",
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
-      "fileMatch": ["declarations.sh"],
+      "fileMatch": ["src/declarations.sh"],
       "matchStrings": [ "VERSION[OEMUNLOCKONBOOT]=\\$\\{VERSION[OEMUNLOCKONBOOT]:-(?<currentValue>.*?)\\}" ],
       "depNameTemplate": "chenxiaolong/avbroot",
       "datasourceTemplate": "github-releases"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,7 +7,7 @@
       "customType": "regex",
       "fileMatch": ["src/declarations.sh"],
       "matchStrings": [ "VERSION[AFSR]=\\$\\{VERSION[AFSR]:-(?<currentValue>.*?)\\}" ],
-      "depNameTemplate": "chenxiaolong/avbroot",
+      "depNameTemplate": "chenxiaolong/afsr",
       "datasourceTemplate": "github-releases"
     },
    {
@@ -21,35 +21,35 @@
       "customType": "regex",
       "fileMatch": ["src/declarations.sh"],
       "matchStrings": [ "VERSION[ALTERINSTALLER]=\\$\\{VERSION[ALTERINSTALLER]:-(?<currentValue>.*?)\\}" ],
-      "depNameTemplate": "chenxiaolong/avbroot",
+      "depNameTemplate": "chenxiaolong/alterinstaller",
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
       "fileMatch": ["src/declarations.sh"],
       "matchStrings": [ "VERSION[CUSTOTA]=\\$\\{VERSION[CUSTOTA]:-(?<currentValue>.*?)\\}" ],
-      "depNameTemplate": "chenxiaolong/avbroot",
+      "depNameTemplate": "chenxiaolong/custota",
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
       "fileMatch": ["src/declarations.sh"],
       "matchStrings": [ "VERSION[MSD]=\\$\\{VERSION[MSD]:-(?<currentValue>.*?)\\}" ],
-      "depNameTemplate": "chenxiaolong/avbroot",
+      "depNameTemplate": "chenxiaolong/msd",
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
       "fileMatch": ["src/declarations.sh"],
       "matchStrings": [ "VERSION[BCR]=\\$\\{VERSION[BCR]:-(?<currentValue>.*?)\\}" ],
-      "depNameTemplate": "chenxiaolong/avbroot",
+      "depNameTemplate": "chenxiaolong/bcr",
       "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
       "fileMatch": ["src/declarations.sh"],
       "matchStrings": [ "VERSION[OEMUNLOCKONBOOT]=\\$\\{VERSION[OEMUNLOCKONBOOT]:-(?<currentValue>.*?)\\}" ],
-      "depNameTemplate": "chenxiaolong/avbroot",
+      "depNameTemplate": "chenxiaolong/oemunlockonboot",
       "datasourceTemplate": "github-releases"
     }
   ]

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       logLevel:
-        description: Log level
+        description: Log levels based on severity. DEBUG, INFO, WARN, ERROR, FATAL
         required: false
-        default: 'debug'
+        default: 'info'
         type: string
   push:
     branches:


### PR DESCRIPTION
this should fix renovate not updating dependencies.

in addition to that, we should now not be using `debug` for renovate at all. `info` should more than be enough.

should close #27