### PR TITLE
fix: assignees in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,7 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   prHourlyLimit: 0,
   gitAuthor: "Renovate Bot <renovatebot@non-existent-email.com>",
-  assignees: "pixincreate",
+  assignees: ["pixincreate"],
   labels: ["dependencies"],
   customManagers: [
     {


### PR DESCRIPTION
for god's sake, i should stop working in a hurry

assignees is supposed to be an array and not a string which resulted in renovate to fail