### PR TITLE
refactor: revamp env reader and clean up

### DIFF
--- a/env.toml
+++ b/env.toml
@@ -1,3 +1,3 @@
 [device]
-device_name = "bluejay"
-update_channel = "alpha"
+DEVICE_NAME = "bluejay"
+'GRAPHENEOS[UPDATE_CHANNEL]' = "alpha"

--- a/src/fetcher.sh
+++ b/src/fetcher.sh
@@ -24,7 +24,7 @@ function get_latest_version() {
   GRAPHENEOS[OTA_TARGET]="${DEVICE_NAME}-${GRAPHENEOS[UPDATE_TYPE]}-${latest_grapheneos_version}"
   # e.g. https://releases.grapheneos.org/bluejay-stable
   GRAPHENEOS[OTA_URL]="${GRAPHENEOS[OTA_BASE_URL]}/${GRAPHENEOS[OTA_TARGET]}.zip"
-  
+
   # e.g.  bluejay-ota_update-2024080200
   echo -e "GrapheneOS OTA target: \`${GRAPHENEOS[OTA_TARGET]}\`\nGrapheneOS OTA URL: ${GRAPHENEOS[OTA_URL]}\n"
 

--- a/src/util_functions.sh
+++ b/src/util_functions.sh
@@ -44,7 +44,7 @@ function check_and_download_dependencies() {
       continue
     fi
 
-    if [ -f "${WORKDIR}/tools/${tool}" ]; then
+    if [ -d "${WORKDIR}/tools/${tool}" ]; then
       echo -e "\`${tool}\` file already exists in \`${WORKDIR}/tools\`."
       continue
     fi

--- a/src/util_functions.sh
+++ b/src/util_functions.sh
@@ -455,20 +455,13 @@ function check_toml_env() {
 }
 
 function supported_tools() {
-  local arg="${1:-}"
   local tools=("avbroot" "afsr" "alterinstaller" "custota" "custota-tool" "msd" "bcr" "oemunlockonboot" "my-avbroot-setup")
-
-  if [[ "${arg}" == "cdd" ]]; then
-    echo "${tools[@]}"
-    return
-  fi
 
   echo -e "Supported tools:"
   for tool in "${tools[@]}"; do
     echo -e "- ${tool}"
   done
   echo -e "- magisk"
-  exit 0
 }
 
 function help() {


### PR DESCRIPTION
previously, we used to hard code every single env that is used in the `env.toml`. it is not scalable in any way. so, this pr changes that by making it more generic and this makes it possible for us to pass as many env as possible without overriding defaults set in `declarations`.

additionally, this pr also cleans up unwanted crap in `supported_tools` function.