### PR TITLE
fix: make supported tools return valid tools

### DIFF
--- a/src/util_functions.sh
+++ b/src/util_functions.sh
@@ -461,8 +461,14 @@ function check_toml_env() {
 }
 
 function supported_tools() {
+  local arg="${1:-}"
   local tools=("avbroot" "afsr" "alterinstaller" "custota" "custota-tool" "msd" "bcr" "oemunlockonboot" "my-avbroot-setup")
 
+  if [[ "${arg}" == "cdd" ]]; then
+    echo "${tools[@]}"
+    return
+  fi
+  
   echo -e "Supported tools:"
   for tool in "${tools[@]}"; do
     echo -e "- ${tool}"


### PR DESCRIPTION
#51 induced an error where `cdd` arg was removed that resulted in script to fail tools download resulting in entire script to fail.

this pr aims to fix that.

closes #58