### PR TITLE
fix: download deps if non-existent while creating ota

### DIFF
--- a/src/util_functions.sh
+++ b/src/util_functions.sh
@@ -94,6 +94,13 @@ function flag_check() {
 
 # Function to create and make the release called by main script
 function create_and_make_release() {
+  if [[ ! -d $WORKDIR ]]; then
+    echo -e "Error: $WORKDIR is non-existent. Downloading the tools..."
+
+    # Check for requirements and download them accordingly
+    check_and_download_dependencies
+  fi
+
   # Calls the download_ota function to download the OTA if not found
   download_ota
   # Calls the create_ota function to create the OTA


### PR DESCRIPTION
this pr will throw an error and then download the dependencies to `workdir` if non-existent.