### PR TITLE
release.yml: Use $GRAPHENEOS_VERSION that was set in previous step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,18 +95,18 @@ jobs:
           build_flavor=$([[ ${{ github.event.inputs.root == 'true' }} == 'true' ]] && echo 'magisk' || echo 'rootless')
 
           # Check if the tag exists
-          if git show-ref --tags ${VERSION[GRAPHENEOS]} --quiet; then
-            echo -e "Tag with GrapheneOS version ${VERSION[GRAPHENEOS]} already exists. Looking for assets..."
+          if git show-ref --tags $GRAPHENEOS_VERSION --quiet; then
+            echo -e "Tag with GrapheneOS version $GRAPHENEOS_VERSION already exists. Looking for assets..."
             # Fetch the release information for the tag
-            repo_url="https://api.github.com/repos/${{ github.repository }}/releases/tags/${VERSION[GRAPHENEOS]}"
+            repo_url="https://api.github.com/repos/${{ github.repository }}/releases/tags/$GRAPHENEOS_VERSION"
             release_info=$(curl -sL "$repo_url")
 
             # Define required assets
             required_assets=(
-              "${{ env.DEVICE_NAME }}-${VERSION[GRAPHENEOS]}-magisk-*.zip"
-              "${{ env.DEVICE_NAME }}-${VERSION[GRAPHENEOS]}-magisk-*.zip.csig"
-              "${{ env.DEVICE_NAME }}-${VERSION[GRAPHENEOS]}-rootless-*.zip"
-              "${{ env.DEVICE_NAME }}-${VERSION[GRAPHENEOS]}-rootless-*.zip.csig"
+              "${{ env.DEVICE_NAME }}-$GRAPHENEOS_VERSION-magisk-*.zip"
+              "${{ env.DEVICE_NAME }}-$GRAPHENEOS_VERSION-magisk-*.zip.csig"
+              "${{ env.DEVICE_NAME }}-$GRAPHENEOS_VERSION-rootless-*.zip"
+              "${{ env.DEVICE_NAME }}-$GRAPHENEOS_VERSION-rootless-*.zip.csig"
             )
 
             existing_assets=$(echo "$release_info" | jq -r '.assets[].name')
@@ -152,7 +152,7 @@ jobs:
               fi
             fi
           else
-            echo -e "Tag with GrapheneOS version ${VERSION[GRAPHENEOS]} does not exist. Creating one..."
+            echo -e "Tag with GrapheneOS version $GRAPHENEOS_VERSION does not exist. Creating one..."
           fi
 
       - name: Setup Git


### PR DESCRIPTION
Scheduled builds are currently broken, because the new "Check if a build exists already and verify assets" step is trying to use `${VERSION[GRAPHENEOS]}`, which is set in the newly split previous step.

I fixed this by using `$GRAPHENEOS_VERSION` instead, which is exported by said step. Scheduled builds are now working again in my fork.