### PR TITLE
feat: force update, multi-device releases and CI smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Check shell syntax
+        run: |
+          for file in src/*.sh src/ci/*.sh; do
+            bash -n "$file"
+          done
+
+      - name: Shellcheck
+        run: shellcheck -S warning src/*.sh src/ci/*.sh
+
+      - name: Check env.toml parsing
+        shell: bash
+        run: |
+          source src/util_functions.sh && check_toml_env
+
+      - name: Check download URLs
+        run: src/ci/smoke_test.sh

--- a/.github/workflows/multi-release.yml
+++ b/.github/workflows/multi-release.yml
@@ -1,0 +1,86 @@
+name: Patch and Release OTA for Multiple Devices
+
+# Fans out one `release.yml` run per device.
+# This workflow is meant for forks that build for more than one device.
+# It never runs on a schedule and does not affect single device setups.
+
+on:
+  workflow_dispatch:
+    inputs:
+      devices:
+        description: 'Comma-separated device code names. With root, append the Magisk preinit device per entry. For example: "bluejay:sda8, panther:sda15" or "bluejay, panther". Leave empty to use `DEVICES` from env.toml'
+        required: false
+      root:
+        description: Add root to the builds
+        required: false
+        type: boolean
+        default: false
+      update-channel:
+        description: GrapheneOS update channel. Supports `alpha`, `beta` and `stable`. Defaults to `stable`
+        required: false
+      release-type:
+        description: 'How to handle the release. `default`: build and publish if new. `build-only`: only build. `force-publish`: build and publish even if it exists.'
+        required: true
+        type: choice
+        options:
+          - default
+          - build-only
+          - force-publish
+        default: default
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      devices: ${{ steps.parse.outputs.devices }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Parse device list
+        id: parse
+        env:
+          DEVICES_INPUT: ${{ inputs.devices }}
+        run: |
+          devices_raw="${DEVICES_INPUT}"
+
+          # Fall back to `DEVICES` from env.toml when the input is empty
+          if [[ -z "${devices_raw}" ]]; then
+            source src/util_functions.sh && check_toml_env
+            devices_raw="${DEVICES:-}"
+          fi
+
+          if [[ -z "${devices_raw}" ]]; then
+            echo "::error::No devices given. Fill the \`devices\` input or set \`DEVICES\` in env.toml."
+            exit 1
+          fi
+
+          # Turn "bluejay:sda8, panther" into [{"device": "bluejay", "preinit": "sda8"}, {"device": "panther", "preinit": ""}]
+          devices=$(jq -cn --arg list "$devices_raw" '
+            $list | split(",")
+                  | map(gsub("^\\s+|\\s+$"; ""))
+                  | map(select(length > 0) | split(":") | {device: .[0], preinit: (.[1] // "")})
+          ')
+
+          if [[ $(jq 'length' <<<"$devices") -eq 0 ]]; then
+            echo "::error::No devices found in: $devices_raw"
+            exit 1
+          fi
+
+          echo "devices=$devices" >> $GITHUB_OUTPUT
+
+  release:
+    needs: matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.matrix.outputs.devices) }}
+    permissions: write-all
+    uses: ./.github/workflows/release.yml
+    with:
+      device-id: ${{ matrix.target.device }}
+      root: ${{ inputs.root }}
+      magisk-preinit-device: ${{ matrix.target.preinit }}
+      update-channel: ${{ inputs.update-channel }}
+      release-type: ${{ inputs.release-type }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,32 @@ on:
           - force-publish
         default: default
 
+  # Allows this workflow to be called per device, see multi-release.yml
+  workflow_call:
+    inputs:
+      device-id:
+        required: true
+        type: string
+      root:
+        required: false
+        type: boolean
+        default: false
+      magisk-preinit-device:
+        required: false
+        type: string
+      update-channel:
+        required: false
+        type: string
+      release-type:
+        required: false
+        type: string
+        default: default
+
 env:
   CARGO_INCREMENTAL: 1
-  DEVICE_NAME: ${{ github.event.inputs.device-id }}
+  DEVICE_NAME: ${{ inputs.device-id }}
   INTERACTIVE_MODE: false
-  GRAPHENEOS_UPDATE_CHANNEL: ${{ github.event.inputs.update-channel }}
+  GRAPHENEOS_UPDATE_CHANNEL: ${{ inputs.update-channel }}
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
 
@@ -50,8 +71,8 @@ jobs:
       - name: Check if `magisk-preinit-device` is set when `root` is true
         run: |
           # Convert inputs to proper boolean values
-          root=${{ github.event.inputs.root }}
-          magisk_preinit_device=${{ github.event.inputs.magisk-preinit-device }}
+          root="${{ inputs.root }}"
+          magisk_preinit_device="${{ inputs.magisk-preinit-device }}"
 
           # Ensure that the boolean comparison is correctly handled
           if [ "$root" == "true" ] && [ -z "$magisk_preinit_device" ]; then
@@ -73,6 +94,7 @@ jobs:
 
           echo "DEVICE_NAME=${DEVICE_NAME}" >> $GITHUB_ENV
           echo "GRAPHENEOS_UPDATE_CHANNEL=${GRAPHENEOS[UPDATE_CHANNEL]}" >> $GITHUB_ENV
+          echo "FORCE_UPDATE=${FORCE_UPDATE:-false}" >> $GITHUB_ENV
 
       - name: Set GrapheneOS version
         shell: bash
@@ -89,71 +111,11 @@ jobs:
 
       - name: Check if a build exists already and verify assets
         shell: bash
-        if: github.event_name == 'schedule' || github.event.inputs.release-type == 'default'
-        run: |
-          # Determine if the build is based on magisk or rootless (build flavor)
-          build_flavor=$([[ ${{ github.event.inputs.root == 'true' }} == 'true' ]] && echo 'magisk' || echo 'rootless')
-
-          # Check if the tag exists
-          if git show-ref --tags $GRAPHENEOS_VERSION --quiet; then
-            echo -e "Tag with GrapheneOS version $GRAPHENEOS_VERSION already exists. Looking for assets..."
-            # Fetch the release information for the tag
-            repo_url="https://api.github.com/repos/${{ github.repository }}/releases/tags/$GRAPHENEOS_VERSION"
-            release_info=$(curl -sL "$repo_url")
-
-            # Define required assets
-            required_assets=(
-              "${{ env.DEVICE_NAME }}-$GRAPHENEOS_VERSION-magisk-*.zip"
-              "${{ env.DEVICE_NAME }}-$GRAPHENEOS_VERSION-magisk-*.zip.csig"
-              "${{ env.DEVICE_NAME }}-$GRAPHENEOS_VERSION-rootless-*.zip"
-              "${{ env.DEVICE_NAME }}-$GRAPHENEOS_VERSION-rootless-*.zip.csig"
-            )
-
-            existing_assets=$(echo "$release_info" | jq -r '.assets[].name')
-            missing_assets=()
-
-            for required_asset in "${required_assets[@]}"; do
-              # Convert wildcard pattern to regex
-              regex="${required_asset//\*/.*}"
-
-              for asset in "${existing_assets[@]}"; do
-                # if existing asset matches the required asset, break the loop
-                if ! [[ $asset =~ $regex ]]; then
-                  missing_assets+=("$required_asset")
-                  break
-                fi
-              done
-            done
-
-            if [ ${#missing_assets[@]} -eq 0 ]; then
-              echo -e "::error::All required assets are present. Exiting..."
-              exit 1
-            else
-              echo -e "Missing assets:"
-              for missing_asset in "${missing_assets[@]}"; do
-                echo -e "  - $missing_asset"
-              done
-
-              # Grep always throws an error stating it cannot find the file or directory
-              valid_build=""
-              for missing_asset in "${missing_assets[@]}"; do
-                if [[ $missing_asset == *"$build_flavor"* ]]; then
-                  valid_build="$build_flavor"
-                  break
-                fi
-              done
-
-              # Check if valid_build is either "magisk" or "rootless"
-              if [[ "$valid_build" == "magisk" ]] || [[ "$valid_build" == "rootless" ]]; then
-                echo -e "Proceeding with build to create missing assets..."
-              else
-                echo -e "::error::Asset with \`$build_flavor\` flavor already exists!"
-                exit 1
-              fi
-            fi
-          else
-            echo -e "Tag with GrapheneOS version $GRAPHENEOS_VERSION does not exist. Creating one..."
-          fi
+        if: github.event_name == 'schedule' || inputs.release-type == 'default'
+        env:
+          REPOSITORY: ${{ github.repository }}
+          ROOT: ${{ inputs.root }}
+        run: src/ci/check_existing_build.sh
 
       - name: Setup Git
         run: |
@@ -188,9 +150,9 @@ jobs:
       - name: Patch OTA
         shell: bash
         env:
-          ADDITIONALS_ROOT: ${{ github.event.inputs.root }}
+          ADDITIONALS_ROOT: ${{ inputs.root }}
           CLEANUP: true
-          MAGISK_PREINIT: ${{ github.event.inputs.magisk-preinit-device }}
+          MAGISK_PREINIT: ${{ inputs.magisk-preinit-device }}
           PASSPHRASE_AVB: ${{ secrets.PASSPHRASE_AVB }}
           PASSPHRASE_OTA: ${{ secrets.PASSPHRASE_OTA }}
         run: |
@@ -212,7 +174,7 @@ jobs:
 
       - name: Make Release
         uses: softprops/action-gh-release@v3
-        if: github.event.inputs.release-type != 'build-only'
+        if: inputs.release-type != 'build-only'
         with:
           body_path: ${{ github.workspace }}-CHANGELOG.txt
           files: |
@@ -221,50 +183,19 @@ jobs:
           name: "${{ env.GRAPHENEOS_VERSION }}"
           tag_name: "${{ env.GRAPHENEOS_VERSION }}"
 
+      - name: Remove superseded release assets
+        shell: bash
+        if: env.FORCE_REBUILD == 'true' && inputs.release-type != 'build-only'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          ROOT: ${{ inputs.root }}
+        run: src/ci/remove_superseded_assets.sh
+
       - name: Publish OTA to server
         shell: bash
-        if: github.event.inputs.release-type != 'build-only'
-        run: |
-          CURRENT_COMMIT=$(git rev-parse --short HEAD)
-          FLAVOR=("magisk" "rootless")
-          root=${{ github.event.inputs.root }}
-
-          # Create `magisk` and `rootless` directories if they don't exist
-          mkdir -p "${FLAVOR}"
-
-          # Switch to gh-pages branch
-          git checkout gh-pages
-          echo -e "Updating Configs for the new release..."
-
-          # If root is true or the the release has `magisk` in <device_name>.json, use magisk flavor
-          if [ "${root}" = "true" ] || grep -q magisk "${{ env.DEVICE_NAME }}.json"; then
-            TARGET_FILE="${FLAVOR[0]}/${{ env.DEVICE_NAME }}.json"
-          else
-            TARGET_FILE="${FLAVOR[1]}/${{ env.DEVICE_NAME }}.json"
-          fi
-
-          echo -e "Updating Configs for the new release..."
-
-          # Check if the target file exists, if not create an empty one to avoid any issues
-          if [ ! -f "${TARGET_FILE}" ]; then
-            echo -e "touching ${TARGET_FILE}..."
-            touch "${TARGET_FILE}"
-          fi
-
-          # Copy from `./` to `./<flavor>/` if same tag doesn't exist in the target file or if it's a force-publish
-          if [[ "${{ github.event.inputs.release-type }}" == "force-publish" ]] || ! grep -q "${{ env.GRAPHENEOS_VERSION }}" "${TARGET_FILE}"; then
-            echo -e "Copying ${{ env.DEVICE_NAME }}.json to ${TARGET_FILE}..."
-            cp "${{ env.DEVICE_NAME }}.json" "${TARGET_FILE}"
-            git add "${TARGET_FILE}"
-          else
-            echo -e "Deployed version (${{ env.GRAPHENEOS_VERSION }}) is same as current GrapheneOS release (${{ env.GRAPHENEOS_VERSION }}).\nUpdate skipped."
-          fi
-
-          # Commit and push the changes if the working directory is clean
-          if ! git diff-index --quiet HEAD; then
-            git commit -m "release("${CURRENT_COMMIT}"): bump GrapheneOS version to ${{ env.GRAPHENEOS_VERSION }}"
-            git push origin gh-pages
-          fi
-
-          # Switch back to main branch
-          git checkout main
+        if: inputs.release-type != 'build-only'
+        env:
+          RELEASE_TYPE: ${{ inputs.release-type }}
+          ROOT: ${{ inputs.root }}
+        run: src/ci/publish_ota.sh

--- a/README.md
+++ b/README.md
@@ -268,6 +268,11 @@ PixeneOS can be run on your local machine. A Linux based machine is preferred.
 
 `INTERACTIVE_MODE`, by default is set to `true` that calls `check_toml_env` function to check the existence of `env.toml`. If the file exist, it will read the `env.toml` file and set the environment variables accordingly. If the `env.toml` is non-existent, ignored. If it exist, and the format is wrong, the script exits with an error.
 
+Configuration is layered.
+`src/declarations.sh` sets the defaults, `env.toml` overrides them, and workflow inputs override both.
+In CI, `env.toml` is read only on scheduled runs.
+Manual runs take all values from the workflow inputs.
+
 To make the patched OTA available to the device, it needs to be hosted on the server. PixeneOS uses GitHub for pushing updates, handled by [release.yml](.github/workflows/release.yml).
 
 To set up automated release, add the following variables in GitHub secrets:
@@ -280,6 +285,22 @@ To set up automated release, add the following variables in GitHub secrets:
 - Passphrases used to generate the keys:
   - `PASSPHRASE_AVB`
   - `PASSPHRASE_OTA`
+
+### Force Update
+
+By default, scheduled runs skip the build when a release for the current GrapheneOS version and flavor already exists.
+Set `FORCE_UPDATE = "true"` in `env.toml` to let scheduled runs rebuild the current version when a module gets an update.
+The check compares the module versions in `src/declarations.sh` against the commit that built the existing release asset.
+A rebuild replaces the previous asset of the same device and flavor on the release.
+To force a build manually, run [release.yml](.github/workflows/release.yml) from the Actions tab and set `release-type` to `force-publish`.
+
+### Multiple Devices
+
+Use [multi-release.yml](.github/workflows/multi-release.yml) to build for more than one device.
+It starts one release run per device from a comma-separated list, for example `bluejay, panther`.
+With root enabled, append the Magisk preinit device to each entry, for example `bluejay:sda8, panther:sda15`.
+Leave the `devices` input empty to use the `DEVICES` value from `env.toml`, so you do not have to type the list on every run.
+This workflow runs only manually and does not affect single device setups.
 
 ### Hop Between Root and Rootless
 

--- a/env.toml
+++ b/env.toml
@@ -1,3 +1,9 @@
 [device]
 DEVICE_NAME = "bluejay"
 'GRAPHENEOS[UPDATE_CHANNEL]' = "alpha"
+# Used by multi-release.yml when its `devices` input is left empty
+# DEVICES = "bluejay:sda8, panther"
+
+[build]
+# Set to "true" to rebuild the current release when a module gets an update
+FORCE_UPDATE = "false"

--- a/src/ci/check_existing_build.sh
+++ b/src/ci/check_existing_build.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# Decide whether the release workflow needs to build.
+# Exits with 0 to build and 1 to skip.
+#
+# Reads from the environment:
+#   DEVICE_NAME         Device code name
+#   GRAPHENEOS_VERSION  GrapheneOS version to release
+#   REPOSITORY          GitHub repository as `owner/name`
+#   ROOT                "true" builds the magisk flavor, anything else rootless
+#   FORCE_UPDATE        "true" rebuilds the current version on module updates
+#
+# Writes FORCE_REBUILD=true to GITHUB_ENV when an existing asset gets replaced.
+
+set -o nounset -o pipefail -o errexit
+
+build_flavor=$([[ "${ROOT:-false}" == "true" ]] && echo 'magisk' || echo 'rootless')
+
+# Check if the tag exists
+if ! git show-ref --tags "${GRAPHENEOS_VERSION}" --quiet; then
+  echo -e "Tag with GrapheneOS version ${GRAPHENEOS_VERSION} does not exist. Creating one..."
+  exit 0
+fi
+
+echo -e "Tag with GrapheneOS version ${GRAPHENEOS_VERSION} already exists. Looking for assets..."
+# Fetch the release information for the tag
+repo_url="https://api.github.com/repos/${REPOSITORY}/releases/tags/${GRAPHENEOS_VERSION}"
+# `.assets[]?` keeps the script alive when the tag has no release
+existing_assets=$(curl -sL "${repo_url}" | jq -r '.assets[]?.name')
+
+# Assets of the current flavor, e.g. bluejay-2026081300-rootless-abc1234.zip
+zip_regex="^${DEVICE_NAME}-${GRAPHENEOS_VERSION}-${build_flavor}-.*\.zip$"
+existing_zip=$(grep -E "${zip_regex}" <<<"${existing_assets}" | head -n1 || true)
+existing_csig=$(grep -E "${zip_regex%$}\.csig$" <<<"${existing_assets}" | head -n1 || true)
+
+if [[ -z "${existing_zip}" || -z "${existing_csig}" ]]; then
+  echo -e "Assets with \`${build_flavor}\` flavor are missing. Proceeding with build..."
+  exit 0
+fi
+
+if [[ "${FORCE_UPDATE:-false}" != "true" ]]; then
+  echo -e "::error::Asset with \`${build_flavor}\` flavor already exists!"
+  exit 1
+fi
+
+# FORCE_UPDATE is enabled: rebuild the current GrapheneOS version only if a
+# module got an update since the commit that built the existing asset.
+# The commit hash is part of the asset name, see generate_ota_info.
+last_commit=$(sed -E 's/^.*-([0-9a-f]{7,40})(-dirty)?\.zip$/\1/' <<<"${existing_zip}")
+
+if ! git cat-file -e "${last_commit}^{commit}" 2>/dev/null; then
+  echo -e "Commit \`${last_commit}\` from asset \`${existing_zip}\` is unknown. Proceeding with rebuild..."
+  echo "FORCE_REBUILD=true" >>"${GITHUB_ENV:-/dev/null}"
+  exit 0
+fi
+
+module_changes=$(git diff "${last_commit}" HEAD -- src/declarations.sh | grep -E '^[+-]VERSION\[' || true)
+if [[ -z "${module_changes}" ]]; then
+  echo -e "No module updates since \`${last_commit}\`. Skipping rebuild..."
+  exit 1
+fi
+
+echo -e "Module updates since \`${last_commit}\`:\n${module_changes}\nProceeding with rebuild..."
+echo "FORCE_REBUILD=true" >>"${GITHUB_ENV:-/dev/null}"

--- a/src/ci/publish_ota.sh
+++ b/src/ci/publish_ota.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Publish the update info of a release to the OTA server (the gh-pages branch).
+#
+# Reads from the environment:
+#   DEVICE_NAME         Device code name
+#   GRAPHENEOS_VERSION  GrapheneOS version of the release
+#   ROOT                "true" targets the magisk flavor
+#   RELEASE_TYPE        `force-publish` updates the server even without changes
+
+set -o nounset -o pipefail -o errexit
+
+CURRENT_COMMIT=$(git rev-parse --short HEAD)
+FLAVOR=("magisk" "rootless")
+
+# Create `magisk` and `rootless` directories if they don't exist
+mkdir -p "${FLAVOR[@]}"
+
+# Switch to gh-pages branch
+git checkout gh-pages
+echo -e "Updating Configs for the new release..."
+
+# If root is true or the release has `magisk` in <device_name>.json, use magisk flavor
+if [ "${ROOT:-false}" = "true" ] || grep -q magisk "${DEVICE_NAME}.json"; then
+  TARGET_FILE="${FLAVOR[0]}/${DEVICE_NAME}.json"
+else
+  TARGET_FILE="${FLAVOR[1]}/${DEVICE_NAME}.json"
+fi
+
+# Check if the target file exists, if not create an empty one to avoid any issues
+if [ ! -f "${TARGET_FILE}" ]; then
+  echo -e "touching ${TARGET_FILE}..."
+  touch "${TARGET_FILE}"
+fi
+
+# Copy from `./` to `./<flavor>/` if the update info changed or if it's a force-publish
+# A plain version check is not enough: a force rebuild keeps the version but changes the asset URL
+if [[ "${RELEASE_TYPE:-}" == "force-publish" ]] || ! cmp -s "${DEVICE_NAME}.json" "${TARGET_FILE}"; then
+  echo -e "Copying ${DEVICE_NAME}.json to ${TARGET_FILE}..."
+  cp "${DEVICE_NAME}.json" "${TARGET_FILE}"
+  git add "${TARGET_FILE}"
+else
+  echo -e "Deployed version (${GRAPHENEOS_VERSION}) is same as current GrapheneOS release (${GRAPHENEOS_VERSION}).\nUpdate skipped."
+fi
+
+# Commit and push the changes if there is something to publish
+if ! git diff-index --quiet HEAD; then
+  git commit -m "release(${CURRENT_COMMIT}): bump GrapheneOS version to ${GRAPHENEOS_VERSION}"
+  # Rebase to survive concurrent pushes from parallel device builds, see multi-release.yml
+  git pull --rebase origin gh-pages
+  git push origin gh-pages
+fi
+
+# Switch back to main branch
+git checkout main

--- a/src/ci/remove_superseded_assets.sh
+++ b/src/ci/remove_superseded_assets.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Delete older assets of the current device and flavor from the release.
+# Keeps a single build per device and flavor. Without this, rebuilds pile up
+# assets and the module update check keeps matching the oldest asset.
+#
+# Reads from the environment:
+#   DEVICE_NAME          Device code name
+#   GRAPHENEOS_VERSION   GrapheneOS version of the release
+#   OUTPUTS_PATCHED_OTA  File name of the build that has to stay
+#   REPOSITORY           GitHub repository as `owner/name`
+#   ROOT                 "true" targets the magisk flavor, anything else rootless
+#   GH_TOKEN             Token for the `gh` CLI
+
+set -o nounset -o pipefail -o errexit
+
+build_flavor=$([[ "${ROOT:-false}" == "true" ]] && echo 'magisk' || echo 'rootless')
+
+gh release view "${GRAPHENEOS_VERSION}" --repo "${REPOSITORY}" --json assets --jq '.assets[].name' |
+  { grep -E "^${DEVICE_NAME}-${GRAPHENEOS_VERSION}-${build_flavor}-" || true; } |
+  { grep -v -F "${OUTPUTS_PATCHED_OTA}" || true; } |
+  while read -r asset; do
+    echo "Deleting superseded asset: ${asset}"
+    gh release delete-asset "${GRAPHENEOS_VERSION}" "${asset}" --repo "${REPOSITORY}" --yes
+  done

--- a/src/ci/smoke_test.sh
+++ b/src/ci/smoke_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Verify that every download URL the project constructs still resolves.
+# Catches renamed release assets and version drift before a release run does.
+
+set -o nounset -o pipefail -o errexit
+
+source src/util_functions.sh
+
+FAILED=0
+
+function check_url() {
+  local name="${1}"
+  local url="${2}"
+  local status
+
+  status=$(curl -sIL -o /dev/null -w '%{http_code}' "${url}")
+  if [[ "${status}" == "200" ]]; then
+    echo "ok   ${name}: ${url}"
+  else
+    echo "::error::FAIL ${name} (HTTP ${status}): ${url}"
+    FAILED=1
+  fi
+}
+
+# Read the device configuration and resolve the latest versions
+check_toml_env
+get_latest_version
+
+# Tools and modules from declarations
+tool_list=$(supported_tools "cdd")
+IFS=' ' read -r -a tools_array <<<"${tool_list}"
+
+for tool in "${tools_array[@]}"; do
+  # `my-avbroot-setup` is a git repository, cloning is checked elsewhere
+  if [[ "${tool}" == "my-avbroot-setup" ]]; then
+    continue
+  fi
+
+  construct_url "${tool}"
+  check_url "${tool}" "${URL}"
+  check_url "${tool}.sig" "${SIGNATURE_URL}"
+done
+
+# Magisk APK from the fork's latest tag
+check_url "magisk" "${MAGISK[URL]}/releases/download/${VERSION[MAGISK]}/Magisk-${VERSION[MAGISK]}.apk"
+
+# GrapheneOS OTA for the configured device
+check_url "grapheneos-ota" "${GRAPHENEOS[OTA_URL]}"
+
+exit "${FAILED}"

--- a/src/declarations.sh
+++ b/src/declarations.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # Declare associative arrays and variables
+# shellcheck disable=SC2034  # the variables are used by the scripts that source this file
 declare -A ADDITIONALS
 declare -A AVBROOT
 declare -A GRAPHENEOS
@@ -15,8 +16,9 @@ ARCH="x86_64-unknown-linux-gnu" # for Linux
 # ARCH="x86_64-pc-windows-msvc" # for Windows
 
 # Initial setup environment variables
-CLEANUP="${CLEANUP:-'false'}"                # Clean up after the script finishes
+CLEANUP="${CLEANUP:-false}"                  # Clean up after the script finishes
 DEVICE_NAME="${DEVICE_NAME:-}"               # Device name, passed from the CI environment
+FORCE_UPDATE="${FORCE_UPDATE:-false}"        # Rebuild the current release when a module gets an update
 INTERACTIVE_MODE="${INTERACTIVE_MODE:-true}" # Enable interactive mode
 WORKDIR=".tmp"
 

--- a/src/fetcher.sh
+++ b/src/fetcher.sh
@@ -6,17 +6,22 @@ source src/declarations.sh
 
 # Fetch the latest version of GrapheneOS and Magisk and sets up the OTA URL
 function get_latest_version() {
-  local latest_grapheneos_version=$(curl -sL "${GRAPHENEOS[OTA_BASE_URL]}/${DEVICE_NAME}-${GRAPHENEOS[UPDATE_CHANNEL]}" | sed 's/ .*//')
-  local latest_magisk_version=$(
+  local latest_grapheneos_version
+  local latest_magisk_version
+
+  latest_grapheneos_version=$(curl -sL "${GRAPHENEOS[OTA_BASE_URL]}/${DEVICE_NAME}-${GRAPHENEOS[UPDATE_CHANNEL]}" | sed 's/ .*//')
+  # Annotated tags produce an extra `<tag>^{}` entry that must not become the version
+  latest_magisk_version=$(
     git ls-remote --tags "${DOMAIN}/${MAGISK[REPOSITORY]}.git" |
       awk -F'\t' '{print $2}' |
       grep -E 'refs/tags/' |
+      grep -v '\^{}$' |
       sed 's/refs\/tags\///' |
       sort -V |
       tail -n1
   )
 
-  if [[ GRAPHENEOS[UPDATE_TYPE] == "install" ]]; then
+  if [[ "${GRAPHENEOS[UPDATE_TYPE]}" == "install" ]]; then
     echo -e "The update type is set to \`install\` which is not supported by AVBRoot.\nExiting..."
     exit 1
   fi
@@ -93,7 +98,7 @@ function download_ota() {
   local ota="${WORKDIR}/${GRAPHENEOS[OTA_TARGET]}.zip"
 
   # Set the URLs if not set
-  if [ -n "${GRAPHENEOS[OTA_URL]}" ]; then
+  if [ -z "${GRAPHENEOS[OTA_URL]}" ]; then
     get_latest_version
   fi
 

--- a/src/util_functions.sh
+++ b/src/util_functions.sh
@@ -34,7 +34,8 @@ function check_and_download_dependencies() {
   IFS=' ' read -r -a tools_array <<<"${tools}"
 
   for tool in "${tools_array[@]}"; do
-    local flag=$(flag_check "${tool}")
+    local flag
+    flag=$(flag_check "${tool}")
 
     if [[ "${flag}" == 'false' ]]; then
       echo -e "\`${tool}\` is **NOT** enabled in the configuration.\nSkipping...\n"
@@ -79,7 +80,8 @@ function check_and_download_dependencies() {
 # If flag for a tool is disabled, it is not downloaded
 function flag_check() {
   local tool="${1}"
-  local tool_upper_case=$(echo "${tool}" | tr '[:lower:]' '[:upper:]')
+  local tool_upper_case
+  tool_upper_case=$(echo "${tool}" | tr '[:lower:]' '[:upper:]')
 
   if [[ "${tool}" == "my-avbroot-setup" ]]; then
     FLAG="${ADDITIONALS[MY_AVBROOT_SETUP]}"
@@ -166,7 +168,6 @@ function patch_ota() {
 
   # Set the paths
   local ota_zip="${WORKDIR}/${GRAPHENEOS[OTA_TARGET]}"
-  local pkmd="${KEYS[PKMD]}"
   local grapheneos_pkmd="${WORKDIR}/extracted/avb_pkmd.bin"
   local grapheneos_otacert="${WORKDIR}/extracted/ota/META-INF/com/android/otacert"
   local magisk_path="${WORKDIR}/modules/magisk.apk"
@@ -185,8 +186,8 @@ function patch_ota() {
 
   # At present, the script lacks the ability to disable certain modules.
   # Everything is hardcoded to be enabled by default.
-  if ls "${ota_zip}.patched*.zip" 1>/dev/null 2>&1; then
-    echo -e "File ${ota_zip}.pathed.zip already exists in local. Patch skipped."
+  if [[ -f "${OUTPUTS[PATCHED_OTA]}" ]]; then
+    echo -e "File ${OUTPUTS[PATCHED_OTA]} already exists in local. Patch skipped."
   else
     echo -e "Patching OTA..."
     local args=()
@@ -270,7 +271,9 @@ function env_setup() {
 
   # Add the paths to the PATH environment variable just so that the script can find them
   if ! command -v avbroot &>/dev/null && ! command -v afsr &>/dev/null && ! command -v custota-tool &>/dev/null; then
-    export PATH="$(realpath ${afsr}):$(realpath ${avbroot}):$(realpath ${custota_tool}):$PATH"
+    local tool_paths
+    tool_paths="$(realpath "${afsr}"):$(realpath "${avbroot}"):$(realpath "${custota_tool}")"
+    export PATH="${tool_paths}:${PATH}"
   fi
 
   # Enabled python virtual environment
@@ -293,8 +296,9 @@ function env_setup() {
 # Function to enable the python virtual environment
 function enable_venv() {
   local dir_path='' # Default value is empty string
-  local base_path=$(basename "$(pwd)")
   local venv_path=''
+  local base_path
+  base_path=$(basename "$(pwd)")
 
   # Check presence of venv
   # Create a virtual environment if not found
@@ -321,25 +325,25 @@ function enable_venv() {
 
   # Ensure venv_path is set correctly and activate the virtual environment
   if [ -f "${venv_path}" ]; then
+    # shellcheck source=/dev/null
     source "${venv_path}"
   else
     echo -e "Virtual environment activation script not found at \`${venv_path}\`."
   fi
 }
 
-# Construct URL for the tools and download them
-# This function is called by download_dependencies function when running in non-interactive mode
-function url_constructor() {
+# Construct download URLs for a tool or module
+# Sets URL and SIGNATURE_URL without downloading anything
+function construct_url() {
   local repository="${1}"
   local user='chenxiaolong'
-  INTERACTIVE_MODE="${2:-true}"
+  local repository_upper_case
+  repository_upper_case=$(echo "${repository}" | tr '[:lower:]' '[:upper:]')
 
-  local repository_upper_case=$(echo "${repository}" | tr '[:lower:]' '[:upper:]')
-
-  echo -e "Constructing URL for \`${repository}\` as \`${repository}\` is non-existent at \`${WORKDIR}\`..."
   # `my-avbroot-setup` is git repository
   if [[ "${repository}" == "my-avbroot-setup" ]]; then
     URL="${DOMAIN}/${user}/${repository}"
+    SIGNATURE_URL=""
   else
     # Afsr, avbroot, and custota-tool are binaries and are platform dependent. Modules are zipped files.
     if [[ "${repository}" == "afsr" || "${repository}" == "avbroot" || "${repository}" == "custota-tool" ]]; then
@@ -364,7 +368,16 @@ function url_constructor() {
     URL="${download_page}/${version}/${application}"
     SIGNATURE_URL="${download_page}/${version}/${application}.sig"
   fi
+}
 
+# Construct URL for the tools and download them
+# This function is called by download_dependencies function when running in non-interactive mode
+function url_constructor() {
+  local repository="${1}"
+  INTERACTIVE_MODE="${2:-true}"
+
+  echo -e "Constructing URL for \`${repository}\` as \`${repository}\` is non-existent at \`${WORKDIR}\`..."
+  construct_url "${repository}"
   echo -e "URL for \`${repository}\`: ${URL}"
 
   # If the script is running in interactive mode, prompt the user to overwrite the existing files
@@ -452,7 +465,8 @@ function make_directories() {
 
 function generate_ota_info() {
   # Detect build flavor
-  local flavor=$([[ ${ADDITIONALS[ROOT]} == 'true' ]] && echo "magisk-${VERSION[MAGISK]}" || echo "rootless")
+  local flavor
+  flavor=$([[ ${ADDITIONALS[ROOT]} == 'true' ]] && echo "magisk-${VERSION[MAGISK]}" || echo "rootless")
   # e.g. bluejay-2024082200-rootless-abc12345-dirty.zip
   OUTPUTS[PATCHED_OTA]="${DEVICE_NAME}-${VERSION[GRAPHENEOS]}-${flavor}-$(git rev-parse --short HEAD)$(dirty_suffix).zip"
 }
@@ -474,7 +488,8 @@ function check_toml_env() {
       echo -e "Found variables in \`${toml_file}\` and will take precedence over other values.\n"
       for key in "${!config_vars[@]}"; do
         echo -e "${key}: ${config_vars[$key]}"
-        eval "${key}=${config_vars[$key]}"
+        # printf -v keeps values with spaces or commas intact, eval would split them
+        printf -v "${key}" '%s' "${config_vars[$key]}"
       done
     else
       echo -e "Failed to find the required variables in \`${toml_file}\`.\n"

--- a/src/verifier.sh
+++ b/src/verifier.sh
@@ -62,8 +62,9 @@ function verify_downloads() {
     return $?
   fi
 
-  # Check if signatures are present for all downloaded files except for `my-avbroot-setup` and `magisk`
-  if [[ ! -n "$(ls "${WORKDIR}/signatures/"*.sig 2>/dev/null)" && "${tool}" != "my-avbrot-setup" && "${tool}" != "magisk" ]]; then
+  # Check if the signature is present, `my-avbroot-setup` and `magisk` do not have one
+  if [[ "${tool}" != "my-avbroot-setup" && "${tool}" != "magisk" ]] &&
+    [[ ! -f "${WORKDIR}/signatures/${tool}.zip.sig" ]]; then
     echo -e "Error: Signature for \`${tool}\` not found in \`${WORKDIR}/signatures\`\n"
     auto_retry_check
     return $?


### PR DESCRIPTION
## What

- Scheduled runs can rebuild the current GrapheneOS version when a module gets an update. Opt in with `FORCE_UPDATE = "true"` in `env.toml`. Superseded release assets are removed after the new upload.
- New `multi-release.yml` workflow: one release run per device. Device list comes from the `devices` input or `DEVICES` in `env.toml`. Each entry can carry its own Magisk preinit device, for example `bluejay:sda8`.
- Release workflow shell logic moved to `src/ci/` scripts. `release.yml` is now glue only and callable per device.
- New CI workflow on pull requests: shell syntax, shellcheck, `env.toml` parsing, and a check that every download URL still resolves.

## Fixes

- Magisk version resolution could pick a `^{}` tag entry and break the download URL
- `GRAPHENEOS[UPDATE_TYPE]` guard compared literal text and never fired
- Signature verification accepted any signature in the directory instead of the tool's own
- Patch skip check tested a quoted glob and could never match
- gh-pages update info was skipped when only the asset URL changed

Closes #66
Closes #301