### PR TITLE
feat: logging, module toggles and env.toml user config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
           done
 
       - name: Shellcheck
-        run: shellcheck -S warning src/*.sh src/ci/*.sh
+        # `-x` follows the source chain from the entry points, so cross-file
+        # variable usage is visible and needs no suppressions
+        run: shellcheck -x -S warning src/main.sh src/setup_hooks.sh src/ci/*.sh
 
       - name: Check env.toml parsing
         shell: bash

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Configuration is layered.
 `src/declarations.sh` sets the defaults, `env.toml` overrides them, and workflow inputs override both.
 In CI, `env.toml` is read only on scheduled runs.
 Manual runs take all values from the workflow inputs.
+Forks set `GITHUB_USER` and `GITHUB_REPO` in `env.toml` so `src/declarations.sh` stays untouched.
 
 To make the patched OTA available to the device, it needs to be hosted on the server. PixeneOS uses GitHub for pushing updates, handled by [release.yml](.github/workflows/release.yml).
 

--- a/env.toml
+++ b/env.toml
@@ -7,3 +7,10 @@ DEVICE_NAME = "bluejay"
 [build]
 # Set to "true" to rebuild the current release when a module gets an update
 FORCE_UPDATE = "false"
+# Build architecture, defaults to Linux. See declarations.sh for the values
+# ARCH = "x86_64-unknown-linux-gnu"
+
+[github]
+# Set these when running a fork, used for the Magisk fork and OTA server URLs
+# GITHUB_USER = "pixincreate"
+# GITHUB_REPO = "PixeneOS"

--- a/env.toml
+++ b/env.toml
@@ -9,8 +9,12 @@ DEVICE_NAME = "bluejay"
 FORCE_UPDATE = "false"
 # Build architecture, defaults to Linux. See declarations.sh for the values
 # ARCH = "x86_64-unknown-linux-gnu"
+# Disable a bundled module, for example BCR
+# 'ADDITIONALS[BCR]' = "false"
 
 [github]
-# Set these when running a fork, used for the Magisk fork and OTA server URLs
+# Set these when running a fork, used for the OTA server URL
 # GITHUB_USER = "pixincreate"
 # GITHUB_REPO = "PixeneOS"
+# Magisk source, defaults to pixincreate/Magisk with Zygisk fixes for GrapheneOS
+# 'MAGISK[REPOSITORY]' = "topjohnwu/Magisk"

--- a/src/ci/smoke_test.sh
+++ b/src/ci/smoke_test.sh
@@ -14,7 +14,8 @@ function check_url() {
   local url="${2}"
   local status
 
-  status=$(curl -sIL -o /dev/null -w '%{http_code}' "${url}")
+  # `|| true` keeps errexit from ending the run, a failed request reports as 000
+  status=$(curl -sIL --max-time 30 --retry 2 -o /dev/null -w '%{http_code}' "${url}" || true)
   if [[ "${status}" == "200" ]]; then
     echo "ok   ${name}: ${url}"
   else

--- a/src/ci/smoke_test.sh
+++ b/src/ci/smoke_test.sh
@@ -43,8 +43,8 @@ for tool in "${tools_array[@]}"; do
   check_url "${tool}.sig" "${SIGNATURE_URL}"
 done
 
-# Magisk APK from the fork's latest tag
-check_url "magisk" "${MAGISK[URL]}/releases/download/${VERSION[MAGISK]}/Magisk-${VERSION[MAGISK]}.apk"
+# Magisk APK from the latest tag of the configured repository
+check_url "magisk" "${DOMAIN}/${MAGISK[REPOSITORY]}/releases/download/${VERSION[MAGISK]}/Magisk-${VERSION[MAGISK]}.apk"
 
 # GrapheneOS OTA for the configured device
 check_url "grapheneos-ota" "${GRAPHENEOS[OTA_URL]}"

--- a/src/declarations.sh
+++ b/src/declarations.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034  # the variables are used by the scripts that source this file
 
 source src/logger.sh
 
 # Declare associative arrays and variables
 declare -A ADDITIONALS
-declare -A AVBROOT
 declare -A GRAPHENEOS
 declare -A KEYS
 declare -A MAGISK
@@ -43,8 +41,9 @@ VERSION[OEMUNLOCKONBOOT]="${VERSION[OEMUNLOCKONBOOT]:-1.4}"
 
 # Magisk
 MAGISK[PREINIT]="${MAGISK_PREINIT:-}"
-MAGISK[REPOSITORY]="${GITHUB_USER}/Magisk"
-MAGISK[URL]="${DOMAIN}/${MAGISK[REPOSITORY]}"
+# The default fork carries Zygisk fixes for GrapheneOS.
+# Set to `topjohnwu/Magisk` for upstream Magisk.
+MAGISK[REPOSITORY]="${MAGISK_REPOSITORY:-pixincreate/Magisk}"
 
 # Keys
 KEYS[AVB]="${KEYS[AVB]:-avb.key}"
@@ -53,7 +52,6 @@ KEYS[CERT_OTA]="${KEYS[CERT_OTA]:-ota.crt}"
 KEYS[CERT_OTA_BASE64]="${KEYS[CERT_OTA_BASE64]:-''}"
 KEYS[OTA]="${KEYS[OTA]:-ota.key}"
 KEYS[OTA_BASE64]="${KEYS[OTA_BASE64]:-''}"
-KEYS[PKMD]="${KEYS[PKMD]:-avb_pkmd.bin}"
 
 # GrapheneOS
 GRAPHENEOS[OTA_BASE_URL]="https://releases.grapheneos.org"

--- a/src/declarations.sh
+++ b/src/declarations.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034  # the variables are used by the scripts that source this file
+
+source src/logger.sh
 
 # Declare associative arrays and variables
-# shellcheck disable=SC2034  # the variables are used by the scripts that source this file
 declare -A ADDITIONALS
 declare -A AVBROOT
 declare -A GRAPHENEOS
@@ -11,9 +13,9 @@ declare -A OUTPUTS
 declare -A VERSION
 
 # Build Specifications
-ARCH="x86_64-unknown-linux-gnu" # for Linux
-# ARCH="universal-apple-darwin" # for macOS
-# ARCH="x86_64-pc-windows-msvc" # for Windows
+# `x86_64-unknown-linux-gnu` for Linux, `universal-apple-darwin` for macOS,
+# `x86_64-pc-windows-msvc` for Windows. Override in env.toml.
+ARCH="${ARCH:-x86_64-unknown-linux-gnu}"
 
 # Initial setup environment variables
 CLEANUP="${CLEANUP:-false}"                  # Clean up after the script finishes
@@ -22,10 +24,10 @@ FORCE_UPDATE="${FORCE_UPDATE:-false}"        # Rebuild the current release when 
 INTERACTIVE_MODE="${INTERACTIVE_MODE:-true}" # Enable interactive mode
 WORKDIR=".tmp"
 
-# GitHub variables
+# GitHub variables. Override GITHUB_USER and GITHUB_REPO in env.toml for forks.
 DOMAIN="https://github.com"
-REPOSITORY="PixeneOS" # GitHub repository name
-USER="pixincreate"    # GitHub username
+GITHUB_REPO="${GITHUB_REPO:-PixeneOS}"    # GitHub repository name
+GITHUB_USER="${GITHUB_USER:-pixincreate}" # GitHub username
 
 # Application version variables
 VERSION[AFSR]="${VERSION[AFSR]:-2.0.0}"
@@ -41,7 +43,7 @@ VERSION[OEMUNLOCKONBOOT]="${VERSION[OEMUNLOCKONBOOT]:-1.4}"
 
 # Magisk
 MAGISK[PREINIT]="${MAGISK_PREINIT:-}"
-MAGISK[REPOSITORY]="${USER}/Magisk"
+MAGISK[REPOSITORY]="${GITHUB_USER}/Magisk"
 MAGISK[URL]="${DOMAIN}/${MAGISK[REPOSITORY]}"
 
 # Keys

--- a/src/declarations.sh
+++ b/src/declarations.sh
@@ -52,6 +52,7 @@ KEYS[CERT_OTA]="${KEYS[CERT_OTA]:-ota.crt}"
 KEYS[CERT_OTA_BASE64]="${KEYS[CERT_OTA_BASE64]:-''}"
 KEYS[OTA]="${KEYS[OTA]:-ota.key}"
 KEYS[OTA_BASE64]="${KEYS[OTA_BASE64]:-''}"
+KEYS[PKMD]="${KEYS[PKMD]:-avb_pkmd.bin}"
 
 # GrapheneOS
 GRAPHENEOS[OTA_BASE_URL]="https://releases.grapheneos.org"

--- a/src/exchange.sh
+++ b/src/exchange.sh
@@ -9,7 +9,7 @@ source src/declarations.sh
 # The encoded keys can be used in the CI pipelines
 function base64_encode() {
   local success_status=false
-  echo -e "\nEncoding keys to base64..."
+  log "Encoding keys to base64..."
 
   KEYS[AVB_BASE64]=$(base64 -w0 "${KEYS[AVB]}") && echo "KEYS[AVB_BASE64]=${KEYS[AVB_BASE64]}" && success_status=true
   KEYS[OTA_BASE64]=$(base64 -w0 "${KEYS[OTA]}") && echo "KEYS[OTA_BASE64]=${KEYS[OTA_BASE64]}" && success_status=true
@@ -19,9 +19,9 @@ function base64_encode() {
     export KEYS_AVB_BASE64="${KEYS[AVB_BASE64]}"
     export KEYS_OTA_BASE64="${KEYS[OTA_BASE64]}"
     export KEYS_CERT_OTA_BASE64="${KEYS[CERT_OTA_BASE64]}"
-    echo -e "Encoded keys to base64.\n"
+    log "Encoded keys to base64.\n"
   else
-    echo "Failed to encode keys to base64.\n"
+    error "Failed to encode keys to base64.\n"
     exit 1
   fi
 }
@@ -29,17 +29,17 @@ function base64_encode() {
 # This function is called in CI workflows to decode the base64 keys to files (avb.key, ota.key, ota.crt)
 function base64_decode() {
   local success_status=false
-  echo -e "\nDecoding keys from base64..."
+  log "Decoding keys from base64..."
 
   # Check if any of the KEYS or individual key values are empty
   if [ -z "${KEYS[AVB_BASE64]}" ] || [ -z "${KEYS[CERT_OTA_BASE64]}" ] || [ -z "${KEYS[OTA_BASE64]}" ] ||
     [ -z "${KEYS_AVB_BASE64:-}" ] || [ -z "${KEYS_CERT_OTA_BASE64:-}" ] || [ -z "${KEYS_OTA_BASE64:-}" ]; then
-    echo "Error: One or more BASE64 encoded values are empty. Please ensure all required keys are set."
+    error "One or more BASE64 encoded values are empty. Please ensure all required keys are set."
     exit 1
   fi
 
   # Continue with the rest of the script if all values are non-empty
-  echo -e "All KEY values are set. Proceeding with decoding..."
+  log "All KEY values are set. Proceeding with decoding..."
 
   KEYS[AVB_BASE64]="${KEYS_AVB_BASE64:-${KEYS[AVB_BASE64]}}"
   KEYS[CERT_OTA_BASE64]="${KEYS_CERT_OTA_BASE64:-${KEYS[CERT_OTA_BASE64]}}"
@@ -57,7 +57,7 @@ function base64_decode() {
       echo "${base64_key}" | base64 --decode >"${output_file}"
 
       if [[ $? -ne 0 ]]; then
-        echo "Error decoding base64 for ${key}"
+        error "Decoding base64 failed for ${key}"
         success_status=false
       else
         # Decodes ${key} to ${output_file}"
@@ -65,15 +65,15 @@ function base64_decode() {
         success_status=true
       fi
     else
-      echo "No base64 data found for ${key}"
+      error "No base64 data found for ${key}"
       success_status=false
     fi
   done
 
   if [[ "${success_status}" == true ]]; then
-    echo -e "Decoded keys from base64.\n"
+    log "Decoded keys from base64.\n"
   else
-    echo "Failed to decode keys from base64.\n"
+    error "Failed to decode keys from base64.\n"
     exit 1
   fi
 }

--- a/src/fetcher.sh
+++ b/src/fetcher.sh
@@ -22,7 +22,7 @@ function get_latest_version() {
   )
 
   if [[ "${GRAPHENEOS[UPDATE_TYPE]}" == "install" ]]; then
-    echo -e "The update type is set to \`install\` which is not supported by AVBRoot.\nExiting..."
+    error "The update type is set to \`install\` which is not supported by AVBRoot.\nExiting..."
     exit 1
   fi
 
@@ -32,10 +32,10 @@ function get_latest_version() {
   GRAPHENEOS[OTA_URL]="${GRAPHENEOS[OTA_BASE_URL]}/${GRAPHENEOS[OTA_TARGET]}.zip"
 
   # e.g.  bluejay-ota_update-2024080200
-  echo -e "GrapheneOS OTA target: \`${GRAPHENEOS[OTA_TARGET]}\`\nGrapheneOS OTA URL: ${GRAPHENEOS[OTA_URL]}\n"
+  log "GrapheneOS OTA target: \`${GRAPHENEOS[OTA_TARGET]}\`\nGrapheneOS OTA URL: ${GRAPHENEOS[OTA_URL]}\n"
 
   if [[ -z "${latest_grapheneos_version}" ]]; then
-    echo -e "Failed to get the latest version."
+    error "Failed to get the latest version."
     exit 1
   fi
 
@@ -44,7 +44,7 @@ function get_latest_version() {
   fi
 
   if [[ -z "${latest_magisk_version}" ]]; then
-    echo -e "Failed to get the latest Magisk version."
+    error "Failed to get the latest Magisk version."
     exit 1
   else
     VERSION[MAGISK]="${latest_magisk_version}"
@@ -57,7 +57,7 @@ function get() {
   local url="${2}"
   local signature_url="${3:-}"
 
-  echo "Downloading \`${filename}\`..."
+  log "Downloading \`${filename}\`..."
 
   # `my-avbroot-setup` is a special case as it is a git repository
   if [[ "${filename}" == "my-avbroot-setup" ]]; then
@@ -75,22 +75,22 @@ function get() {
     if [[ "${filename}" != "my-avbroot-setup" ]]; then
       # Download signatures
       if [ -n "${signature_url}" ]; then
-        echo "Downloading signature for \`${filename}\`..."
+        log "Downloading signature for \`${filename}\`..."
         curl -sLf "${signature_url}" --output "${WORKDIR}/signatures/${filename}.zip.sig"
       fi
 
       # afsr, avbroot and custota-tool are binaries that need to be extracted and granted permissions
       if [[ "${filename}" == "afsr" || "${filename}" == "avbroot" || "${filename}" == "custota-tool" ]]; then
-        echo -e "Extracting and granting permissions for \`${filename}\`..."
+        log "Extracting and granting permissions for \`${filename}\`..."
         echo N | unzip -q -o "${WORKDIR}/modules/${filename}.zip" -d "${WORKDIR}/tools/${filename}"
         chmod +x "${WORKDIR}/tools/${filename}/${filename}"
 
-        echo -e "Cleaning up..."
+        log "Cleaning up..."
         rm "${WORKDIR}/modules/${filename}.zip"
       fi
     fi
   fi
-  echo -e "\`${filename}\` downloaded."
+  log "\`${filename}\` downloaded."
 }
 
 # Function to check and download the dependencies
@@ -104,10 +104,10 @@ function download_ota() {
 
   # Download if not downloaded already
   if [ ! -f "${ota}" ]; then
-    echo -e "Downloading OTA from: ${GRAPHENEOS[OTA_URL]}...\nPlease be patient while the download happens."
+    log "Downloading OTA from: ${GRAPHENEOS[OTA_URL]}...\nPlease be patient while the download happens."
     curl -sL "${GRAPHENEOS[OTA_URL]}" --output "${ota}"
-    echo -e "OTA downloaded to: \`${ota}\`\n"
+    log "OTA downloaded to: \`${ota}\`\n"
   else
-    echo -e "OTA is already downloaded in: \`${ota}\`\n"
+    log "OTA is already downloaded in: \`${ota}\`\n"
   fi
 }

--- a/src/logger.sh
+++ b/src/logger.sh
@@ -3,19 +3,22 @@
 # ---
 # LOGGING
 # Provides simple, timestamped logging functions.
+# Messages may contain escape sequences such as `\n`, `%b` renders them.
 # ---
 
 # Usage: log "Doing something..."
-log() {
-  local timestamp
-  timestamp=$(date +"%Y-%m-%d %T")
-  printf "[%s] [INFO] -- %s\\n" "$timestamp" "$1"
+function log() {
+  printf "[%s] [INFO] -- %b\n" "$(date +"%Y-%m-%d %T")" "${1}"
+}
+
+# Prints a warning message to stderr.
+# Usage: warn "Something looks off."
+function warn() {
+  printf "[%s] [WARN] -- %b\n" "$(date +"%Y-%m-%d %T")" "${1}" >&2
 }
 
 # Prints an error message to stderr.
 # Usage: error "Something went wrong."
-error() {
-  local timestamp
-  timestamp=$(date +"%Y-%m-%d %T")
-  printf "[%s] [ERROR] -- %s\\n" "$timestamp" "$1" >&2
+function error() {
+  printf "[%s] [ERROR] -- %b\n" "$(date +"%Y-%m-%d %T")" "${1}" >&2
 }

--- a/src/main.sh
+++ b/src/main.sh
@@ -11,7 +11,7 @@ source src/util_functions.sh
 
 function main() {
   if [[ "${INTERACTIVE_MODE}" == "true" ]]; then
-    echo -e "Running in interactive mode...\n"
+    log "Running in interactive mode...\n"
     check_toml_env
   fi
 

--- a/src/util_functions.sh
+++ b/src/util_functions.sh
@@ -140,15 +140,14 @@ function cleanup() {
 # Generate the AVB and OTA signing keys.
 # Has to be called manually.
 function generate_keys() {
-  local public_key_metadata='avb_pkmd.bin'
-
   # Generate the AVB and OTA signing keys
   avbroot key generate-key -o "${KEYS[AVB]}"
   avbroot key generate-key -o "${KEYS[OTA]}"
 
   # Convert the public key portion of the AVB signing key to the AVB public key metadata format
   # This is the format that the bootloader requires when setting the custom root of trust
-  avbroot key extract-avb -k "${KEYS[AVB]}" -o "${public_key_metadata}"
+  # Flash it with: fastboot flash avb_custom_key <file>
+  avbroot key encode-avb -k "${KEYS[AVB]}" -o "${KEYS[PKMD]}"
 
   # Generate a self-signed certificate for the OTA signing key
   # This is used by recovery to verify OTA updates when sideloading

--- a/src/util_functions.sh
+++ b/src/util_functions.sh
@@ -66,7 +66,7 @@ function check_and_download_dependencies() {
     RETRY_COUNT=0 # Reset retry count for magisk
     while true; do
       # Magisk is an exception as it is an APK and hence we do the get call directly and verify
-      URL="${MAGISK[URL]}/releases/download/${VERSION[MAGISK]}/Magisk-${VERSION[MAGISK]}.apk"
+      URL="${DOMAIN}/${MAGISK[REPOSITORY]}/releases/download/${VERSION[MAGISK]}/Magisk-${VERSION[MAGISK]}.apk"
       log "URL for \`magisk\`: ${URL}"
       get "magisk" "${URL}"
       verify_downloads "magisk"
@@ -487,10 +487,6 @@ function check_toml_env() {
         # printf -v keeps values with spaces or commas intact, eval would split them
         printf -v "${key}" '%s' "${config_vars[$key]}"
       done
-
-      # Re-derive values that depend on the overrides
-      MAGISK[REPOSITORY]="${GITHUB_USER}/Magisk"
-      MAGISK[URL]="${DOMAIN}/${MAGISK[REPOSITORY]}"
     else
       error "Failed to find the required variables in \`${toml_file}\`.\n"
       exit 1

--- a/src/util_functions.sh
+++ b/src/util_functions.sh
@@ -14,7 +14,7 @@ function check_and_download_dependencies() {
 
   # Check for Python requirements
   if ! command -v python3 &>/dev/null; then
-    echo -e "Python 3 is required to run this script.\nExiting..."
+    error "Python 3 is required to run this script.\nExiting..."
     exit 1
   fi
 
@@ -38,17 +38,17 @@ function check_and_download_dependencies() {
     flag=$(flag_check "${tool}")
 
     if [[ "${flag}" == 'false' ]]; then
-      echo -e "\`${tool}\` is **NOT** enabled in the configuration.\nSkipping...\n"
+      log "\`${tool}\` is **NOT** enabled in the configuration.\nSkipping...\n"
       continue
     fi
 
     if [ -f "${WORKDIR}/modules/${tool}.zip" ]; then
-      echo -e "\`${tool}.zip\` file already exists in \`${WORKDIR}/modules\`."
+      log "\`${tool}.zip\` file already exists in \`${WORKDIR}/modules\`."
       continue
     fi
 
     if [ -d "${WORKDIR}/tools/${tool}" ]; then
-      echo -e "\`${tool}\` file already exists in \`${WORKDIR}/tools\`."
+      log "\`${tool}\` file already exists in \`${WORKDIR}/tools\`."
       continue
     fi
 
@@ -67,7 +67,7 @@ function check_and_download_dependencies() {
     while true; do
       # Magisk is an exception as it is an APK and hence we do the get call directly and verify
       URL="${MAGISK[URL]}/releases/download/${VERSION[MAGISK]}/Magisk-${VERSION[MAGISK]}.apk"
-      echo "URL for \`magisk\`: ${URL}"
+      log "URL for \`magisk\`: ${URL}"
       get "magisk" "${URL}"
       verify_downloads "magisk"
 
@@ -101,7 +101,7 @@ function flag_check() {
 # Function to create and make the release called by main script
 function create_and_make_release() {
   if [[ ! -d $WORKDIR ]]; then
-    echo -e "Error: $WORKDIR is non-existent. Downloading the tools..."
+    warn "$WORKDIR is non-existent. Downloading the tools..."
 
     # Check for requirements and download them accordingly
     check_and_download_dependencies
@@ -127,14 +127,14 @@ function create_ota() {
 # Function to cleanup the temporary files and unset the keys when not in interactive mode
 function cleanup() {
   if [[ "${CLEANUP}" != 'true' ]]; then
-    echo -e "Cleanup is disabled. Exiting...\n"
+    log "Cleanup is disabled. Exiting...\n"
     return
   fi
 
-  echo "Cleaning up..."
+  log "Cleaning up..."
   rm -rf "${WORKDIR}"
   unset "${KEYS[@]}"
-  echo "Cleanup complete."
+  log "Cleanup complete."
 }
 
 # Generate the AVB and OTA signing keys.
@@ -180,16 +180,14 @@ function patch_ota() {
 
   # Extract the official public keys and certificates if not found
   if [[ ! -e "${grapheneos_pkmd}" || ! -e "${grapheneos_otacert}" ]]; then
-    echo "Extracting official keys..."
+    log "Extracting official keys..."
     extract_official_keys
   fi
 
-  # At present, the script lacks the ability to disable certain modules.
-  # Everything is hardcoded to be enabled by default.
   if [[ -f "${OUTPUTS[PATCHED_OTA]}" ]]; then
-    echo -e "File ${OUTPUTS[PATCHED_OTA]} already exists in local. Patch skipped."
+    log "File ${OUTPUTS[PATCHED_OTA]} already exists in local. Patch skipped."
   else
-    echo -e "Patching OTA..."
+    log "Patching OTA..."
     local args=()
 
     # OTA input and output
@@ -209,27 +207,25 @@ function patch_ota() {
     args+=("--pass-avb-env-var" "PASSPHRASE_AVB")
     args+=("--pass-ota-env-var" "PASSPHRASE_OTA")
 
-    # Modules
-    args+=("--module-custota" "${WORKDIR}/modules/custota.zip")
-    args+=("--module-msd" "${WORKDIR}/modules/msd.zip")
-    args+=("--module-bcr" "${WORKDIR}/modules/bcr.zip")
-    args+=("--module-oemunlockonboot" "${WORKDIR}/modules/oemunlockonboot.zip")
-    args+=("--module-alterinstaller" "${WORKDIR}/modules/alterinstaller.zip")
-
-    # Module signatures
-    args+=("--module-custota-sig" "${WORKDIR}/signatures/custota.zip.sig")
-    args+=("--module-msd-sig" "${WORKDIR}/signatures/msd.zip.sig")
-    args+=("--module-bcr-sig" "${WORKDIR}/signatures/bcr.zip.sig")
-    args+=("--module-oemunlockonboot-sig" "${WORKDIR}/signatures/oemunlockonboot.zip.sig")
-    args+=("--module-alterinstaller-sig" "${WORKDIR}/signatures/alterinstaller.zip.sig")
+    # Modules and their signatures
+    # Disabled modules are left out, `patch.py` skips modules without arguments
+    local module
+    for module in custota msd bcr oemunlockonboot alterinstaller; do
+      if [[ "$(flag_check "${module}")" == 'true' ]]; then
+        args+=("--module-${module}" "${WORKDIR}/modules/${module}.zip")
+        args+=("--module-${module}-sig" "${WORKDIR}/signatures/${module}.zip.sig")
+      else
+        log "Module \`${module}\` is disabled. Skipping..."
+      fi
+    done
 
     # Add support for Magisk if root config is enabled
     if [[ "${ADDITIONALS[ROOT]}" == 'true' ]]; then
-      echo -e "Magisk is enabled. Modifying the setup script...\n"
+      log "Magisk is enabled. Modifying the setup script...\n"
       args+=("--patch-arg=--magisk" "--patch-arg" "${magisk_path}")
       args+=("--patch-arg=--magisk-preinit-device" "--patch-arg" "${MAGISK[PREINIT]}")
     else
-      echo -e "Magisk is not enabled. Skipping...\n"
+      log "Magisk is not enabled. Skipping...\n"
     fi
 
     # Have to clear storage space because, `csig` results in storage runout
@@ -248,10 +244,10 @@ function my_avbroot_setup() {
   # Paths
   local setup_script="${WORKDIR}/tools/my-avbroot-setup/patch.py"
   local magisk_path="${WORKDIR}/modules/magisk.apk"
-  local location_path="${DOMAIN}/${USER}/${REPOSITORY}/releases/download/${VERSION[GRAPHENEOS]}/${OUTPUTS[PATCHED_OTA]}"
+  local location_path="${DOMAIN}/${GITHUB_USER}/${GITHUB_REPO}/releases/download/${VERSION[GRAPHENEOS]}/${OUTPUTS[PATCHED_OTA]}"
 
   # Add support to pass env-vars to the setup script for passphrase in the CI/CD pipeline
-  echo -e "Running script modifications..."
+  log "Running script modifications..."
 
   # Update location path to use GitHub releases
   sed -i -e "s|generate_update_info(update_info, args.output.name)|generate_update_info(update_info, '${location_path}')|" "${setup_script}"
@@ -282,14 +278,14 @@ function env_setup() {
   # Install required Python packages
   if [[ -f "${pyproject_file}" ]]; then
     if ! command -v uv &>/dev/null; then
-      echo -e "uv not found. Installing..."
+      warn "uv not found. Installing..."
       python3 -m pip install uv
     fi
 
-    echo -e "Installing required Python packages from pyproject.toml..."
+    log "Installing required Python packages from pyproject.toml..."
     uv pip install -r "${pyproject_file}"
   else
-    echo -e "Warning: pyproject.toml not found at ${my_avbroot_setup}"
+    warn "pyproject.toml not found at ${my_avbroot_setup}"
   fi
 }
 
@@ -304,14 +300,14 @@ function enable_venv() {
   # Create a virtual environment if not found
   if [[ "${base_path}" == "my-avbroot-setup" ]]; then
     if [ ! -d "venv" ]; then
-      echo -e "Virtual environment not found. Creating..."
+      log "Virtual environment not found. Creating..."
       python3 -m venv venv
     fi
   else
-    echo -e "The script is not run from the \`my-avbroot-setup\` directory.\nSearching for the directory..."
+    log "The script is not run from the \`my-avbroot-setup\` directory.\nSearching for the directory..."
     dir_path=$(find . -type d -name "my-avbroot-setup" -print -quit)
     if [ ! -d "${dir_path}/venv" ]; then
-      echo -e "Virtual environment not found in path \`${dir_path}\`. Creating..."
+      log "Virtual environment not found in path \`${dir_path}\`. Creating..."
       python3 -m venv "${dir_path}/venv"
     fi
   fi
@@ -328,7 +324,7 @@ function enable_venv() {
     # shellcheck source=/dev/null
     source "${venv_path}"
   else
-    echo -e "Virtual environment activation script not found at \`${venv_path}\`."
+    warn "Virtual environment activation script not found at \`${venv_path}\`."
   fi
 }
 
@@ -376,9 +372,9 @@ function url_constructor() {
   local repository="${1}"
   INTERACTIVE_MODE="${2:-true}"
 
-  echo -e "Constructing URL for \`${repository}\` as \`${repository}\` is non-existent at \`${WORKDIR}\`..."
+  log "Constructing URL for \`${repository}\` as \`${repository}\` is non-existent at \`${WORKDIR}\`..."
   construct_url "${repository}"
-  echo -e "URL for \`${repository}\`: ${URL}"
+  log "URL for \`${repository}\`: ${URL}"
 
   # If the script is running in interactive mode, prompt the user to overwrite the existing files
   if [[ "${INTERACTIVE_MODE}" == 'true' ]]; then
@@ -387,10 +383,10 @@ function url_constructor() {
       read -r confirm
       confirm=${confirm:-"yes"}
       if [[ $confirm =~ ^[yY](es|ES)?$ ]]; then
-        echo "Removing existing files..."
+        log "Removing existing files..."
         rm -rf "${WORKDIR}/tools/${repository}" "${WORKDIR}/modules/${repository}.zip" "${WORKDIR}/signatures/${repository}.zip.sig"
       else
-        echo "Aborted."
+        error "Aborted."
         exit 1
       fi
     fi
@@ -409,7 +405,7 @@ function download_dependencies() {
   if type url_constructor &>/dev/null; then
     url_constructor "${tool}" "${INTERACTIVE_MODE}"
   else
-    echo -e "Error: \`url_constructor\` function is not defined."
+    error "\`url_constructor\` function is not defined."
     exit 1
   fi
 }
@@ -485,14 +481,18 @@ function check_toml_env() {
     done < <(grep -v '^#' "$toml_file") # Ignore comments
 
     if [[ ${#config_vars[@]} -gt 0 ]]; then
-      echo -e "Found variables in \`${toml_file}\` and will take precedence over other values.\n"
+      log "Found variables in \`${toml_file}\` and will take precedence over other values.\n"
       for key in "${!config_vars[@]}"; do
         echo -e "${key}: ${config_vars[$key]}"
         # printf -v keeps values with spaces or commas intact, eval would split them
         printf -v "${key}" '%s' "${config_vars[$key]}"
       done
+
+      # Re-derive values that depend on the overrides
+      MAGISK[REPOSITORY]="${GITHUB_USER}/Magisk"
+      MAGISK[URL]="${DOMAIN}/${MAGISK[REPOSITORY]}"
     else
-      echo -e "Failed to find the required variables in \`${toml_file}\`.\n"
+      error "Failed to find the required variables in \`${toml_file}\`.\n"
       exit 1
     fi
   fi

--- a/src/verifier.sh
+++ b/src/verifier.sh
@@ -16,15 +16,15 @@ function auto_retry_check() {
   if [[ "${ADDITIONALS[RETRY]}" == "true" ]]; then
     if ((RETRY_COUNT < MAX_RETRIES)); then
       RETRY_COUNT=$((RETRY_COUNT + 1))
-      echo -e "Auto retry is enabled. Retrying (${RETRY_COUNT}/${MAX_RETRIES})...\n"
+      warn "Auto retry is enabled. Retrying (${RETRY_COUNT}/${MAX_RETRIES})...\n"
       RETRY="true"
       return 0
     else
-      echo -e "Maximum retry limit reached. Exiting...\n"
+      error "Maximum retry limit reached. Exiting...\n"
       exit 1
     fi
   else
-    echo -e "Auto retry is not enabled. Exiting...\n"
+    error "Auto retry is not enabled. Exiting...\n"
     exit 1
   fi
 }
@@ -37,7 +37,7 @@ function verify_downloads() {
   local tool="${1}"
   local tool_path=""
 
-  echo "Verifying \`${tool}\`..."
+  log "Verifying \`${tool}\`..."
 
   if [[ -f "${WORKDIR}/modules/${tool}.zip" ]] && [ "${tool}" != "magisk" ]; then
     tool_path="${WORKDIR}/modules/${tool}.zip"
@@ -51,13 +51,13 @@ function verify_downloads() {
   if [[ -e "${tool_path}" ]]; then
     # Check if the tool is a directory or a file
     if [[ -d "${tool_path}" ]]; then
-      echo -e "Tool ${tool} is a directory in \`${WORKDIR}/tools/\`. Verified.\n"
+      log "Tool ${tool} is a directory in \`${WORKDIR}/tools/\`. Verified.\n"
     elif [[ -f "${tool_path}" ]]; then
-      echo -e "Module \`${tool_path}\` found and verified in \`${WORKDIR}/modules/\`.\n"
+      log "Module \`${tool_path}\` found and verified in \`${WORKDIR}/modules/\`.\n"
     fi
     RETRY="false"
   else
-    echo -e "Error: \`${tool}\` not found in \`${WORKDIR}\`\n"
+    error "\`${tool}\` not found in \`${WORKDIR}\`\n"
     auto_retry_check
     return $?
   fi
@@ -65,7 +65,7 @@ function verify_downloads() {
   # Check if the signature is present, `my-avbroot-setup` and `magisk` do not have one
   if [[ "${tool}" != "my-avbroot-setup" && "${tool}" != "magisk" ]] &&
     [[ ! -f "${WORKDIR}/signatures/${tool}.zip.sig" ]]; then
-    echo -e "Error: Signature for \`${tool}\` not found in \`${WORKDIR}/signatures\`\n"
+    error "Signature for \`${tool}\` not found in \`${WORKDIR}/signatures\`\n"
     auto_retry_check
     return $?
   fi


### PR DESCRIPTION
## What

- Wire `src/logger.sh` into all scripts. Progress uses `log`, recoverable conditions use `warn`, failures use `error` on stderr.
- `patch_ota` leaves disabled modules out of the `patch.py` call. `ADDITIONALS[<module>]=false` works end to end now. Before, the download was skipped but the module path was still passed, which broke the patch.
- `USER` and `REPOSITORY` become `GITHUB_USER` and `GITHUB_REPO` with `env.toml` overrides. Forks configure everything in `env.toml` and leave `declarations.sh` untouched. `ARCH` accepts an override too.
- Smoke test requests time out after 30 seconds instead of hanging on a stalled connection.

Covers the "Add logging", "module toggles" and "move user specific variables out of declarations.sh" items in #12.