### PR TITLE
Autoconfigure github username for git creds in actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,11 +122,11 @@ jobs:
 
       - name: Setup Git
         env:
-          MY_EMAIL: ${{ secrets.EMAIL }}
-          GH_NAME: ${{ github.repository_owner }}
+          USER_EMAIL: ${{ secrets.EMAIL }}
+          USER_NAME: ${{ github.repository_owner }}
         run: |
-          git config --global user.email "$MY_EMAIL"
-          git config --global user.name "$GH_NAME"
+          git config --global user.email "$USER_EMAIL"
+          git config --global user.name "$USER_NAME"
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ on:
         description: GrapheneOS update channel. Supports `alpha`, `beta` and `stable`. Defaults to `stable`
         required: false
       release-type:
-        description: 'How to handle the release. `default`: build and publish if new. `build-only`: only build. `force-publish`: build and publish even if it exists.'
+        description: "How to handle the release. `default`: build and publish if new. `build-only`: only build. `force-publish`: build and publish even if it exists."
         required: true
         type: choice
         options:
@@ -121,9 +121,12 @@ jobs:
         run: src/ci/check_existing_build.sh
 
       - name: Setup Git
+        env:
+          MY_EMAIL: ${{ secrets.EMAIL }}
+          GH_NAME: ${{ github.repository_owner }}
         run: |
-          # Configure git for pushing changes
-          git config --global user.email ${{ secrets.EMAIL }} && git config --global user.name PiX
+          git config --global user.email "$MY_EMAIL"
+          git config --global user.name "$GH_NAME"
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
It bothered me that `PiX` was used in the actions as the configured git username, so this should make it automatically pick whatever username the user has. Since I assume this is going to go into personal repos I assumed the `repository_owner` would be fine to use here.